### PR TITLE
MyDNSへのcurl追加

### DIFF
--- a/server/ip_register/src/main.rs
+++ b/server/ip_register/src/main.rs
@@ -3,6 +3,7 @@ extern crate diesel;
 extern crate dotenv;
 
 use regex::Regex;
+use std::env;
 use std::process::Command;
 
 mod conn;
@@ -19,11 +20,18 @@ fn is_ipv4(text: &str) -> bool {
 }
 
 fn main() {
+    let mydns_target = "http://ipv4.mydns.jp/login.html";
+    let mydns_user_and_password = env::var("MYDNS_USER").expect("MYDNS_USER must be set");
+    let _result = Command::new("curl")
+        .args(["-u", &mydns_user_and_password, mydns_target])
+        .output()
+        .expect(&format!("failed to call `curl {}`", mydns_target));
+
     let curl_target = "inet-ip.info";
     let curl_result = Command::new("curl")
         .args([curl_target])
         .output()
-        .expect("failed to call `curl`");
+        .expect(&format!("failed to call `curl {}`", curl_target));
 
     let ipv4_address = String::from_utf8_lossy(&curl_result.stdout).replace("\n", "");
     assert!(is_ipv4(&ipv4_address));


### PR DESCRIPTION
## 関連するIssue
https://github.com/modockey/home-management/issues/19

## 関連するPull Request

## Pull Requestの概要
ip_register起動時にMyDNSへのcurlを行う

## 行ったテスト内容
ローカルで実行し、正常にMyDNSへの登録が行えることを確認

## 備考
サーバーで
`MYDNS_USER`の設定が必要