### PR TITLE
コマンド名修正

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,9 +17,9 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "serve": "serve -s build",
-    "ps2-start": "pm2 start \"serve -s build -l 50080\" --name my-react-app",
-    "ps2-restart": "pm2 restart \"serve -s build -l 50080\" --name my-react-app",
-    "ps2-release": "npm run build && npm run ps2-restart"
+    "pm2-start": "pm2 start \"serve -s build -l 50080\" --name my-react-app",
+    "pm2-restart": "pm2 restart my-react-app",
+    "pm2-release": "npm run build && npm run pm2-restart"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## 関連するIssue
https://github.com/modockey/home-management/issues/20

## 関連するPull Request
https://github.com/modockey/home-management/pull/23
https://github.com/modockey/home-management/pull/24

## Pull Requestの概要
`pm2`コマンド実行時に`ps2`になっていたため修正した
restartコマンドが間違っていたため修正した

## 行ったテスト内容